### PR TITLE
Basic token refreshing logic

### DIFF
--- a/dm/hubs.go
+++ b/dm/hubs.go
@@ -4,6 +4,7 @@ import (
 	// "fmt"
 	"encoding/json"
 	"net/http"
+
 	"github.com/outer-labs/forge-api-go-client/oauth"
 )
 
@@ -13,24 +14,12 @@ type HubAPI struct {
 	HubAPIPath string
 }
 
-type HubAPI3L struct {
-	oauth.ThreeLeggedAuth
-	HubAPIPath string
-}
-
 var api HubAPI
 
 // NewHubAPIWithCredentials returns a Hub API client with default configurations
 func NewHubAPIWithCredentials(ClientID string, ClientSecret string) HubAPI {
 	return HubAPI{
 		oauth.NewTwoLeggedClient(ClientID, ClientSecret),
-		"/project/v1/hubs",
-	}
-}
-
-func NewHubAPI3LWithCredentials(threeLeggedAuth oauth.ThreeLeggedAuth) HubAPI3L {
-	return HubAPI3L{
-		threeLeggedAuth,
 		"/project/v1/hubs",
 	}
 }
@@ -55,26 +44,6 @@ func (api HubAPI) GetHubDetails(hubKey string) (result ForgeResponseObject, err 
 	return getHubDetails(path, hubKey, bearer.AccessToken)
 }
 
-// Hub functions for use with 3legged authentication
-func (api HubAPI3L) GetHubsThreeLegged(bearer oauth.Bearer) (result ForgeResponseArray, err error) {
-
-	//To do? check if access token needs to be refreshed? if so, run bearer.RefreshToken?
-	// if bearer.ExpiresIn 
-	path := "https://developer.api.autodesk.com/project/v1/hubs"
-	return getHubs(path, bearer.AccessToken)
-}
-
-func (api HubAPI3L) GetHubDetailsThreeLegged(bearer oauth.Bearer, hubKey string) (result ForgeResponseObject, err error) {
-	refreshedBearer, err := api.RefreshToken(bearer.RefreshToken, "data:read")
-	if err != nil {
-		return
-	}
-	path := api.Host + api.HubAPIPath
-
-	return getHubDetails(path, hubKey, refreshedBearer.AccessToken)
-}
-
-
 /*
  *	SUPPORT FUNCTIONS
  */
@@ -98,14 +67,14 @@ func getHubs(path, token string) (result ForgeResponseArray, err error) {
 		return
 	}
 	defer response.Body.Close()
-	
+
 	decoder := json.NewDecoder(response.Body)
-		if response.StatusCode != http.StatusOK {
-			err = &ErrorResult{StatusCode:response.StatusCode}
-			decoder.Decode(err)
-				return
-		}
-	
+	if response.StatusCode != http.StatusOK {
+		err = &ErrorResult{StatusCode: response.StatusCode}
+		decoder.Decode(err)
+		return
+	}
+
 	err = decoder.Decode(&result)
 
 	return
@@ -130,14 +99,14 @@ func getHubDetails(path, hubKey, token string) (result ForgeResponseObject, err 
 		return
 	}
 	defer response.Body.Close()
-	
+
 	decoder := json.NewDecoder(response.Body)
-		if response.StatusCode != http.StatusOK {
-			err = &ErrorResult{StatusCode:response.StatusCode}
-			decoder.Decode(err)
-				return
-		}
-	
+	if response.StatusCode != http.StatusOK {
+		err = &ErrorResult{StatusCode: response.StatusCode}
+		decoder.Decode(err)
+		return
+	}
+
 	err = decoder.Decode(&result)
 
 	return

--- a/dm/hubs_three_legged.go
+++ b/dm/hubs_three_legged.go
@@ -77,12 +77,11 @@ func (a *HubAPI3L) refreshTokenIfRequired() error {
 	}
 
 	// TODO: Store expiry time
-	a.BearerToken = &oauth.Bearer{
-		AccessToken:  refreshedBearer.AccessToken,
-		ExpiresIn:    refreshedBearer.ExpiresIn,
-		RefreshToken: refreshedBearer.RefreshToken,
-		TokenType:    refreshedBearer.TokenType,
-	}
+
+	a.BearerToken.AccessToken = refreshedBearer.AccessToken
+	a.BearerToken.ExpiresIn = refreshedBearer.ExpiresIn
+	a.BearerToken.RefreshToken = refreshedBearer.RefreshToken
+	a.BearerToken.TokenType = refreshedBearer.TokenType
 
 	return nil
 }

--- a/dm/hubs_three_legged.go
+++ b/dm/hubs_three_legged.go
@@ -1,0 +1,88 @@
+package dm
+
+import (
+	// "fmt"
+
+	"github.com/outer-labs/forge-api-go-client/oauth"
+)
+
+type HubAPI3L struct {
+	Auth        oauth.ThreeLeggedAuth
+	BearerToken *oauth.Bearer
+	HubAPIPath  string
+}
+
+func NewHubAPI3LWithCredentials(
+	auth oauth.ThreeLeggedAuth,
+	bearer *oauth.Bearer,
+) *HubAPI3L {
+	return &HubAPI3L{
+		Auth:        auth,
+		BearerToken: bearer,
+		HubAPIPath:  "/project/v1/hubs",
+	}
+}
+
+// Hub functions for use with 3legged authentication
+func (a *HubAPI3L) GetHubsThreeLegged() (result ForgeResponseArray, err error) {
+	if err = a.refreshTokenIfRequired(); err != nil {
+		return
+	}
+
+	path := "https://developer.api.autodesk.com/project/v1/hubs"
+	return getHubs(path, a.BearerToken.AccessToken)
+}
+
+func (a *HubAPI3L) GetHubDetailsThreeLegged(hubKey string) (result ForgeResponseObject, err error) {
+	if err = a.refreshTokenIfRequired(); err != nil {
+		return
+	}
+
+	path := a.Auth.Host + api.HubAPIPath
+	return getHubDetails(path, hubKey, a.BearerToken.AccessToken)
+}
+
+func (a *HubAPI3L) ListProjectsThreeLegged(hubKey string) (result ForgeResponseArray, err error) {
+	if err = a.refreshTokenIfRequired(); err != nil {
+		return
+	}
+
+	path := a.Auth.Host + a.HubAPIPath
+	return listProjects(path, hubKey, "", "", "", "", a.BearerToken.AccessToken)
+}
+
+func (a *HubAPI3L) GetProjectDetailsThreeLegged(hubKey, projectKey string) (result ForgeResponseObject, err error) {
+	if err = a.refreshTokenIfRequired(); err != nil {
+		return
+	}
+
+	path := api.Host + api.HubAPIPath
+	return getProjectDetails(path, hubKey, projectKey, a.BearerToken.AccessToken)
+}
+
+func (a *HubAPI3L) GetTopFoldersThreeLegged(hubKey, projectKey string) (result ForgeResponseArray, err error) {
+	if err = a.refreshTokenIfRequired(); err != nil {
+		return
+	}
+
+	path := api.Host + api.HubAPIPath
+	return getTopFolders(path, hubKey, projectKey, a.BearerToken.AccessToken)
+}
+
+func (a *HubAPI3L) refreshTokenIfRequired() error {
+	// TODO: Check expiry time, and return nil if not expired
+	refreshedBearer, err := a.Auth.RefreshToken(a.BearerToken.RefreshToken, "data:read")
+	if err != nil {
+		return err
+	}
+
+	// TODO: Store expiry time
+	a.BearerToken = &oauth.Bearer{
+		AccessToken:  refreshedBearer.AccessToken,
+		ExpiresIn:    refreshedBearer.ExpiresIn,
+		RefreshToken: refreshedBearer.RefreshToken,
+		TokenType:    refreshedBearer.TokenType,
+	}
+
+	return nil
+}

--- a/dm/projects.go
+++ b/dm/projects.go
@@ -3,12 +3,11 @@ package dm
 import (
 	"encoding/json"
 	"net/http"
-	"github.com/outer-labs/forge-api-go-client/oauth"
 )
 
 // ListBuckets returns a list of all buckets created or associated with Forge secrets used for token creation
 func (api HubAPI) ListProjects(hubKey string) (result ForgeResponseArray, err error) {
-	
+
 	// TO DO: take in optional arguments for query params: id, ext, page, limit
 	// https://forge.autodesk.com/en/docs/data/v2/reference/http/hubs-hub_id-projects-GET/
 	bearer, err := api.Authenticate("data:read")
@@ -40,40 +39,6 @@ func (api HubAPI) GetTopFolders(hubKey, projectKey string) (result ForgeResponse
 
 	return getTopFolders(path, hubKey, projectKey, bearer.AccessToken)
 }
-
-// Three-legged api calls
-func (api HubAPI3L) ListProjectsThreeLegged(bearer oauth.Bearer, hubKey string) (result ForgeResponseArray, err error) {
-	
-	refreshedBearer, err := api.RefreshToken(bearer.RefreshToken, "data:read")
-	if err != nil {
-		return
-	}
-
-	path := api.Host + api.HubAPIPath
-	// path := "https://developer.api.autodesk.com/project/v1/hubs"
-	return listProjects(path, hubKey, "", "", "", "", refreshedBearer.AccessToken)
-}
-
-func (api HubAPI3L) GetProjectDetailsThreeLegged(bearer oauth.Bearer, hubKey, projectKey string) (result ForgeResponseObject, err error) {
-	refreshedBearer, err := api.RefreshToken(bearer.RefreshToken, "data:read")
-	if err != nil {
-		return
-	}
-	path := api.Host + api.HubAPIPath
-
-	return getProjectDetails(path, hubKey, projectKey, refreshedBearer.AccessToken)
-}
-
-func (api HubAPI3L) GetTopFoldersThreeLegged(bearer oauth.Bearer, hubKey, projectKey string) (result ForgeResponseArray, err error) {
-	refreshedBearer, err := api.RefreshToken(bearer.RefreshToken, "data:read")
-	if err != nil {
-		return
-	}
-	path := api.Host + api.HubAPIPath
-
-	return getTopFolders(path, hubKey, projectKey, refreshedBearer.AccessToken)
-}
-
 
 /*
  *	SUPPORT FUNCTIONS
@@ -112,11 +77,11 @@ func listProjects(path, hubKey, id, extension, page, limit string, token string)
 		return
 	}
 	defer response.Body.Close()
-  	
-  	decoder := json.NewDecoder(response.Body)
+
+	decoder := json.NewDecoder(response.Body)
 	if response.StatusCode != http.StatusOK {
-    	err = &ErrorResult{StatusCode:response.StatusCode}
-    	decoder.Decode(err)
+		err = &ErrorResult{StatusCode: response.StatusCode}
+		decoder.Decode(err)
 		return
 	}
 
@@ -144,10 +109,10 @@ func getProjectDetails(path, hubKey, projectKey, token string) (result ForgeResp
 	}
 	defer response.Body.Close()
 
-  	decoder := json.NewDecoder(response.Body)
+	decoder := json.NewDecoder(response.Body)
 	if response.StatusCode != http.StatusOK {
-    	err = &ErrorResult{StatusCode:response.StatusCode}
-    	decoder.Decode(err)
+		err = &ErrorResult{StatusCode: response.StatusCode}
+		decoder.Decode(err)
 		return
 	}
 
@@ -175,10 +140,10 @@ func getTopFolders(path, hubKey, projectKey, token string) (result ForgeResponse
 	}
 	defer response.Body.Close()
 
-  	decoder := json.NewDecoder(response.Body)
+	decoder := json.NewDecoder(response.Body)
 	if response.StatusCode != http.StatusOK {
-    	err = &ErrorResult{StatusCode:response.StatusCode}
-    	decoder.Decode(err)
+		err = &ErrorResult{StatusCode: response.StatusCode}
+		decoder.Decode(err)
 		return
 	}
 

--- a/oauth/three_legged.go
+++ b/oauth/three_legged.go
@@ -110,7 +110,6 @@ func (a ThreeLeggedAuth) GetToken(code string) (bearer Bearer, err error) {
 
 // RefreshToken is used to get a new access token by using the refresh token provided by GetToken
 func (a ThreeLeggedAuth) RefreshToken(refreshToken string, scope string) (bearer Bearer, err error) {
-
 	task := http.Client{}
 
 	body := url.Values{}
@@ -119,6 +118,7 @@ func (a ThreeLeggedAuth) RefreshToken(refreshToken string, scope string) (bearer
 	body.Add("grant_type", "refresh_token")
 	body.Add("refresh_token", refreshToken)
 	body.Add("scope", scope)
+	body.Add("redirect_uri", a.RedirectURI)
 
 	req, err := http.NewRequest("POST",
 		a.Host+a.AuthPath+"/refreshtoken",
@@ -128,6 +128,7 @@ func (a ThreeLeggedAuth) RefreshToken(refreshToken string, scope string) (bearer
 	if err != nil {
 		return
 	}
+	d
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	response, err := task.Do(req)
 

--- a/oauth/three_legged.go
+++ b/oauth/three_legged.go
@@ -118,7 +118,6 @@ func (a ThreeLeggedAuth) RefreshToken(refreshToken string, scope string) (bearer
 	body.Add("grant_type", "refresh_token")
 	body.Add("refresh_token", refreshToken)
 	body.Add("scope", scope)
-	body.Add("redirect_uri", a.RedirectURI)
 
 	req, err := http.NewRequest("POST",
 		a.Host+a.AuthPath+"/refreshtoken",
@@ -128,7 +127,7 @@ func (a ThreeLeggedAuth) RefreshToken(refreshToken string, scope string) (bearer
 	if err != nil {
 		return
 	}
-	d
+
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	response, err := task.Do(req)
 


### PR DESCRIPTION
This is a simple strategy for updating the bearer token before requests. It's currently limited to the Hubs API (`HubAPI3L`), but it should be easy to extend to the other APIs.