### PR TITLE
Introduce async token refresher

### DIFF
--- a/dm/folders.go
+++ b/dm/folders.go
@@ -3,6 +3,7 @@ package dm
 import (
 	"encoding/json"
 	"net/http"
+
 	"github.com/outer-labs/forge-api-go-client/oauth"
 )
 
@@ -22,7 +23,7 @@ func NewFolderAPIWithCredentials(ClientID string, ClientSecret string) FolderAPI
 
 // ListBuckets returns a list of all buckets created or associated with Forge secrets used for token creation
 func (api FolderAPI) GetFolderDetails(projectKey, folderKey string) (result ForgeResponseObject, err error) {
-	
+
 	// TO DO: take in optional header arguments
 	// https://forge.autodesk.com/en/docs/data/v2/reference/http/projects-project_id-folders-folder_id-GET/
 	bearer, err := api.Authenticate("data:read")
@@ -65,11 +66,11 @@ func getFolderDetails(path, projectKey, folderKey, token string) (result ForgeRe
 		return
 	}
 	defer response.Body.Close()
-  
-  	decoder := json.NewDecoder(response.Body)
+
+	decoder := json.NewDecoder(response.Body)
 	if response.StatusCode != http.StatusOK {
-    	err = &ErrorResult{StatusCode:response.StatusCode}
-    	decoder.Decode(err)
+		err = &ErrorResult{StatusCode: response.StatusCode}
+		decoder.Decode(err)
 		return
 	}
 
@@ -97,10 +98,10 @@ func getFolderContents(path, projectKey, folderKey, token string) (result ForgeR
 	}
 	defer response.Body.Close()
 
-  	decoder := json.NewDecoder(response.Body)
+	decoder := json.NewDecoder(response.Body)
 	if response.StatusCode != http.StatusOK {
-    	err = &ErrorResult{StatusCode:response.StatusCode}
-    	decoder.Decode(err)
+		err = &ErrorResult{StatusCode: response.StatusCode}
+		decoder.Decode(err)
 		return
 	}
 

--- a/dm/hubs_three_legged.go
+++ b/dm/hubs_three_legged.go
@@ -1,99 +1,66 @@
 package dm
 
-import (
-	// "fmt"
-	"time"
-	"github.com/outer-labs/forge-api-go-client/oauth"
-)
+import "github.com/outer-labs/forge-api-go-client/oauth"
 
 type HubAPI3L struct {
-	Auth        oauth.ThreeLeggedAuth
-	BearerToken *oauth.Bearer
-	HubAPIPath  string
-	TokenExpireTime time.Time
+	Auth       oauth.ThreeLeggedAuth
+	Token      TokenRefresher
+	HubAPIPath string
 }
 
 func NewHubAPI3LWithCredentials(
 	auth oauth.ThreeLeggedAuth,
-	bearer *oauth.Bearer,
+	token TokenRefresher,
 ) *HubAPI3L {
 	return &HubAPI3L{
-		Auth:        auth,
-		BearerToken: bearer,
-		HubAPIPath:  "/project/v1/hubs",
-		TokenExpireTime: time.Now(),
+		Auth:       auth,
+		Token:      token,
+		HubAPIPath: "/project/v1/hubs",
 	}
 }
 
 // Hub functions for use with 3legged authentication
 func (a *HubAPI3L) GetHubsThreeLegged() (result ForgeResponseArray, err error) {
-	if err = a.refreshTokenIfRequired(); err != nil {
+	if err = a.Token.RefreshTokenIfRequired(a.Auth); err != nil {
 		return
 	}
 
 	path := a.Auth.Host + a.HubAPIPath
-	return getHubs(path, a.BearerToken.AccessToken)
+	return getHubs(path, a.Token.Bearer().AccessToken)
 }
 
 func (a *HubAPI3L) GetHubDetailsThreeLegged(hubKey string) (result ForgeResponseObject, err error) {
-	if err = a.refreshTokenIfRequired(); err != nil {
+	if err = a.Token.RefreshTokenIfRequired(a.Auth); err != nil {
 		return
 	}
 
 	path := a.Auth.Host + a.HubAPIPath
-	return getHubDetails(path, hubKey, a.BearerToken.AccessToken)
+	return getHubDetails(path, hubKey, a.Token.Bearer().AccessToken)
 }
 
 func (a *HubAPI3L) ListProjectsThreeLegged(hubKey string) (result ForgeResponseArray, err error) {
-	if err = a.refreshTokenIfRequired(); err != nil {
+	if err = a.Token.RefreshTokenIfRequired(a.Auth); err != nil {
 		return
 	}
 
 	path := a.Auth.Host + a.HubAPIPath
-	return listProjects(path, hubKey, "", "", "", "", a.BearerToken.AccessToken)
+	return listProjects(path, hubKey, "", "", "", "", a.Token.Bearer().AccessToken)
 }
 
 func (a *HubAPI3L) GetProjectDetailsThreeLegged(hubKey, projectKey string) (result ForgeResponseObject, err error) {
-	if err = a.refreshTokenIfRequired(); err != nil {
+	if err = a.Token.RefreshTokenIfRequired(a.Auth); err != nil {
 		return
 	}
 
 	path := a.Auth.Host + a.HubAPIPath
-	return getProjectDetails(path, hubKey, projectKey, a.BearerToken.AccessToken)
+	return getProjectDetails(path, hubKey, projectKey, a.Token.Bearer().AccessToken)
 }
 
 func (a *HubAPI3L) GetTopFoldersThreeLegged(hubKey, projectKey string) (result ForgeResponseArray, err error) {
-	if err = a.refreshTokenIfRequired(); err != nil {
+	if err = a.Token.RefreshTokenIfRequired(a.Auth); err != nil {
 		return
 	}
 
 	path := a.Auth.Host + a.HubAPIPath
-	return getTopFolders(path, hubKey, projectKey, a.BearerToken.AccessToken)
-}
-
-func (a *HubAPI3L) refreshTokenIfRequired() error {
-	
-	// Check if token has expired
-	now := time.Now()
-	expiryTime := a.TokenExpireTime
-	if now.Before(expiryTime){
-		return nil
-	}
-
-	refreshedBearer, err := a.Auth.RefreshToken(a.BearerToken.RefreshToken, "data:read")
-	if err != nil {
-		return err
-	}
-
-	// Refresh "now" and add new token expiration time to API struct along with new credentials
-	now = time.Now()
-	newExpiryTime := now.Add(time.Second * time.Duration(refreshedBearer.ExpiresIn))
-	a.TokenExpireTime = newExpiryTime
-
-	a.BearerToken.AccessToken = refreshedBearer.AccessToken
-	a.BearerToken.ExpiresIn = refreshedBearer.ExpiresIn
-	a.BearerToken.RefreshToken = refreshedBearer.RefreshToken
-	a.BearerToken.TokenType = refreshedBearer.TokenType
-
-	return nil
+	return getTopFolders(path, hubKey, projectKey, a.Token.Bearer().AccessToken)
 }

--- a/dm/token_refresher.go
+++ b/dm/token_refresher.go
@@ -1,0 +1,8 @@
+package dm
+
+import "github.com/outer-labs/forge-api-go-client/oauth"
+
+type TokenRefresher interface {
+	Bearer() *oauth.Bearer
+	RefreshTokenIfRequired(auth oauth.ThreeLeggedAuth) error
+}

--- a/oauth/refreshable_token.go
+++ b/oauth/refreshable_token.go
@@ -1,0 +1,55 @@
+package oauth
+
+import (
+	"sync"
+	"time"
+)
+
+type RefreshableToken struct {
+	bearer          *Bearer
+	TokenExpireTime time.Time
+	readMutex       sync.Mutex
+	writeMutex      sync.Mutex
+}
+
+func NewRefreshableToken(bearer *Bearer) *RefreshableToken {
+	return &RefreshableToken{
+		bearer:          bearer,
+		TokenExpireTime: time.Now(),
+	}
+}
+
+func (t *RefreshableToken) RefreshTokenIfRequired(auth ThreeLeggedAuth) error {
+	t.writeMutex.Lock()
+	defer t.writeMutex.Unlock()
+
+	// Check if token has expired
+	now := time.Now()
+	expiryTime := t.TokenExpireTime
+	if now.Before(expiryTime) {
+		return nil
+	}
+
+	refreshedBearer, err := auth.RefreshToken(t.bearer.RefreshToken, "data:read")
+	if err != nil {
+		return err
+	}
+
+	// Refresh "now" and add new token expiration time to API struct along with new credentials
+	now = time.Now()
+	newExpiryTime := now.Add(time.Second * time.Duration(refreshedBearer.ExpiresIn))
+	t.TokenExpireTime = newExpiryTime
+
+	t.bearer.AccessToken = refreshedBearer.AccessToken
+	t.bearer.ExpiresIn = refreshedBearer.ExpiresIn
+	t.bearer.RefreshToken = refreshedBearer.RefreshToken
+	t.bearer.TokenType = refreshedBearer.TokenType
+
+	return nil
+}
+
+func (t *RefreshableToken) Bearer() *Bearer {
+	t.readMutex.Lock()
+	defer t.readMutex.Unlock()
+	return t.bearer
+}


### PR DESCRIPTION
This allows many async calls to be made to the API without breaking the token refreshing logic. It does require a change in the client software (they how have to supply a `TokenRefresher` when created API objects).