### PR TITLE
Require timestamp in three-legged auth

### DIFF
--- a/oauth/refreshable_token.go
+++ b/oauth/refreshable_token.go
@@ -12,10 +12,10 @@ type RefreshableToken struct {
 	writeMutex      sync.Mutex
 }
 
-func NewRefreshableToken(bearer *Bearer) *RefreshableToken {
+func NewRefreshableToken(bearer *Bearer, expiryTime time.Time) *RefreshableToken {
 	return &RefreshableToken{
 		bearer:          bearer,
-		TokenExpireTime: time.Now(),
+		TokenExpireTime: expiryTime,
 	}
 }
 


### PR DESCRIPTION
This adds the requirement for timestamp to be passed to `ouath.NewRefreshableToken`, which allows the expiry to be store in a client-side session or other storage,