### PR TITLE
Handle large, chunked uploads

### DIFF
--- a/dm/object.go
+++ b/dm/object.go
@@ -2,6 +2,7 @@ package dm
 
 import (
 	"bytes"
+	"crypto/md5"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -169,7 +170,7 @@ const chunkSize = 5000000
 
 func putObjectChunked(path, bucketKey, objectName string, data *bytes.Buffer, token string) (result ObjectDetails, err error) {
 	total := int64(data.Len())
-	sessionId := fmt.Sprintf("%d", time.Now().Unix()) // FIXME: better hash including object name?
+	sessionId := fmt.Sprintf("%x-%d", md5.Sum([]byte(objectName)), time.Now().Unix())
 
 	wg := sync.WaitGroup{}
 	errChan := make(chan error)

--- a/dm/object_test.go
+++ b/dm/object_test.go
@@ -111,11 +111,11 @@ func TestBucketAPI_UploadLargeObject(t *testing.T) {
 
 	bucketAPI := dm.NewBucketAPIWithCredentials(clientID, clientSecret)
 
-	tempBucket := "temp_bucket_for_testing_large_upload"
+	tempBucket := "temp_bucket_for_testing_resumable_upload"
 
-	// this is a fake file. We're using a little over 700mb of data which reliably
+	// this is a fake file. We're using a little over 100mb of data which reliably
 	// fails without chunking.
-	size := 700000100
+	size := 105000000
 	data := bytes.NewBuffer(make([]byte, size))
 
 	t.Run("Create a temp bucket to store an object", func(t *testing.T) {
@@ -136,7 +136,7 @@ func TestBucketAPI_UploadLargeObject(t *testing.T) {
 	})
 
 	t.Run("Upload an object into temp bucket", func(t *testing.T) {
-		result, err := bucketAPI.UploadObject(tempBucket, "temp_file.rvt", data) // doesn't want []byte as data
+		result, err := bucketAPI.UploadObject(tempBucket, "temp_file_chunked.rvt", data) // doesn't want []byte as data
 
 		if err != nil {
 			t.Fatal("Could not upload the test object, got: ", err.Error())

--- a/dm/object_test.go
+++ b/dm/object_test.go
@@ -113,9 +113,9 @@ func TestBucketAPI_UploadLargeObject(t *testing.T) {
 
 	tempBucket := "temp_bucket_for_testing_large_upload"
 
-	// this is a fake file. We're using 700mb of data which reliably
+	// this is a fake file. We're using a little over 700mb of data which reliably
 	// fails without chunking.
-	size := 700000000
+	size := 700000100
 	data := bytes.NewBuffer(make([]byte, size))
 
 	t.Run("Create a temp bucket to store an object", func(t *testing.T) {

--- a/md/api.go
+++ b/md/api.go
@@ -97,6 +97,14 @@ type DerivativeSpec struct {
 	Status       string         `json:"status,omitempty"`
 	Progress     string         `json:"progress,omitempty"`
 	Children     []ChildrenSpec `json:"children,omitempty"`
+	Message      []MessageSpec  `json:"messages,omitempty"`
+}
+
+type MessageSpec struct {
+	Name    string `json:"name,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Message string `json:"message,omitempty"`
+	Code    string `json:"code,omitempty"`
 }
 
 type ChildrenSpec struct {
@@ -268,8 +276,6 @@ func (a ModelDerivativeAPI3L) GetObjectTree3L(urn string, viewId string) (status
 
 	return
 }
-
-
 
 func (a ModelDerivativeAPI) GetPropertiesStream(urn string, viewId string) (status int,
 	result io.ReadCloser, err error) {


### PR DESCRIPTION
This implements a resumable object upload client for objects over 100mb, using the API as defined by https://forge.autodesk.com/en/docs/data/v2/reference/http/buckets-:bucketKey-objects-:objectName-resumable-PUT/